### PR TITLE
Add guacamole

### DIFF
--- a/system/nixos/astoria/configuration.nix
+++ b/system/nixos/astoria/configuration.nix
@@ -18,6 +18,7 @@ in
       ./wm.nix
       ./networking.nix
       ./update-diff.nix
+      ./guacamole.nix
     ];
 
   # Bootloader.

--- a/system/nixos/astoria/guacamole.nix
+++ b/system/nixos/astoria/guacamole.nix
@@ -1,0 +1,7 @@
+{
+  services.guacamole-server = {
+    enable = true;
+    host = "0.0.0.0";
+  };
+  services.guacamole-client.enable = true;
+}


### PR DESCRIPTION
Add guacamole for remote desktop access, though there is a problem I need to get to the bottom of. 

```
Dec 01 17:58:15 astoria guacd[106889]: Guacamole protocol violation. Perhaps the version of guacamole-client is incompatible with this version of guacd?
Dec 01 17:58:15 astoria guacd[106889]: guacd[106889]: ERROR:        Guacamole protocol violation. Perhaps the version of guacamole-client is incompatible with this version of guacd?
```
